### PR TITLE
SpeechRecognitionWorker: Replace strcpy with strcpy_s

### DIFF
--- a/SpeechRecognition/Source/SpeechRecognition/Public/SpeechRecognitionWorker.h
+++ b/SpeechRecognition/Source/SpeechRecognition/Public/SpeechRecognitionWorker.h
@@ -38,10 +38,10 @@ struct FSpeechRecognitionParam
 	// constructor
 	FSpeechRecognitionParam(char* name, ESpeechRecognitionParamType type, char* value) {
 		this->name = new char[strlen(name) + 1];
-		strcpy(this->name, name);
+		strcpy_s(this->name, strlen(name) + 1, name);
 		this->type = type;
 		this->value = new char[strlen(value) + 1];
-		strcpy(this->value, value);
+		strcpy_s(this->value, strlen(value) + 1, value);
 	}
 };
 


### PR DESCRIPTION
Building the plugin produces a warning:

    SpeechRecognitionWorker.h(41): [C4996] 'strcpy': This function
    or variable may be unsafe. Consider using strcpy_s instead.
    To disable deprecation, use _CRT_SECURE_NO_WARNINGS.
    See online help for details.

Reference: https://en.cppreference.com/w/c/string/byte/strcpy